### PR TITLE
fix(table): fixed layout of table-header items (#48)

### DIFF
--- a/projects/components/table/src/subcomponents/table-header.component.ts
+++ b/projects/components/table/src/subcomponents/table-header.component.ts
@@ -45,6 +45,7 @@ import { IPsTableSortDefinition } from '../models';
         display: flex;
         flex-wrap: wrap;
         align-items: flex-end;
+        justify-content: space-between;
       }
 
       .ps-table-header__caption {
@@ -57,7 +58,6 @@ import { IPsTableSortDefinition } from '../models';
 
       .ps-table-header__search {
         flex: 0 1 800px;
-        margin: auto;
       }
 
       .ps-table-header__actions {


### PR DESCRIPTION
If you set header actions and disable the searchbox, the header actions were placed right after the sorting. Now they stay right aligned.

If sorting selection is hidden, the searchbox is now left aligned.